### PR TITLE
Define Networking API

### DIFF
--- a/.github/workflows/issue_create.yaml
+++ b/.github/workflows/issue_create.yaml
@@ -1,0 +1,15 @@
+name: Add labels to new issues
+
+on:
+  issues: 
+    types:
+      - opened
+
+jobs:
+  labeling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels
+        uses: do3-2021/kudo-team-parser-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr_create.yaml
+++ b/.github/workflows/pr_create.yaml
@@ -1,0 +1,15 @@
+name: Add labels to new PRs
+
+on:
+  pull_request: 
+    types:
+      - opened
+
+jobs:
+  labeling:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add labels
+        uses: do3-2021/kudo-team-parser-action@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/proposals/networking.proto
+++ b/docs/proposals/networking.proto
@@ -1,0 +1,31 @@
+syntax = "proto3";
+package networking;
+
+message CreateInterfaceRequest {
+    string ip_address = 1;
+    repeated int32 ports = 2;
+}
+
+message CreateInterfaceResponse {
+    string interface_name = 1;
+}
+
+message DeleteInterfaceRequest {
+    string interface_name = 1;
+}
+
+message CreateContainerNetworkInterfaceRequest {
+    string ip_address = 1;
+    string sub_network = 2;
+}
+
+message CreateContainerNetworkInterfaceResponse {
+    string interface_name = 1;
+}
+
+message Empty {}
+
+service Networking {
+    rpc CreateInterface(CreateInterfaceRequest) returns (CreateInterfaceResponse) {}
+    rpc DeleteInterface(DeleteInterfaceRequest) returns (Empty) {}
+}

--- a/docs/proposals/networking.proto
+++ b/docs/proposals/networking.proto
@@ -28,4 +28,5 @@ message Empty {}
 service Networking {
     rpc CreateInterface(CreateInterfaceRequest) returns (CreateInterfaceResponse) {}
     rpc DeleteInterface(DeleteInterfaceRequest) returns (Empty) {}
+    rpc CreateContainerNetworkInterface(CreateContainerNetworkInterfaceRequest) returns (CreateContainerNetworkInterfaceResponse) {}
 }


### PR DESCRIPTION
## Related issues :
Close #6 

## Overall explanation of your work :

Added proto file defining the API of the networking module.

## Technical decisions you've made and why :

We went with a daemon running on the node for multiples reasons. Right now, a library used by the node-agent or a binary executed by the node agent would have been enough. However, we do not want to restrict our possibilities in later stages of development. Indeed, the next step is to create a multi-node clusters, and our first rounds of thinking all involved a daemon running on each agent. Since it doesn't add much complexity and overhead work to the project, creating a new daemon, accessed through gRPC doesn't look like a bad idea.

## Tasks lists :

- [x] Create interface
- [x] Delete interface