### PR TITLE
Add Controller APIs in the documentation

### DIFF
--- a/docs/proposal/controller/README.md
+++ b/docs/proposal/controller/README.md
@@ -1,0 +1,185 @@
+# External API
+
+---
+
+## Routes
+
+### /instance/
+
+| Method/Route | Description                   | Parameters                 |
+| ------------ | ----------------------------- | -------------------------- |
+| GET /        | get a list of instances       | limit, offset, type, state |
+| GET /{id}    | get detailled info on instance | instanceId             |
+| PUT /        | create an instance            |                            |
+| PATCH /{id}  | update an instance            | instanceId                 |
+| DELETE /{id} | delete an instance            | instanceId                 |
+
+### /workload/
+
+| Method/Route | Description                   | Parameters          |
+| ------------ | ----------------------------- | ------------------- |
+| GET /        | get a list of workloads       | limit, offset, type |
+| GET /{id}    | get detailled info on workload | workloadId       |
+| PUT /        | create a workload             |                     |
+| PATCH /{id}  | update a workload             | workloadId         |
+| DELETE /{id} | delete a workload             | workloadId         |
+
+## External Structures
+
+### Instance
+
+```rust
+struct Instance {
+    id: String,
+    name: String,
+    type: Type,
+    status: Status,
+    uri: String,
+    environment: [String, 100],
+    resources: Resources,
+    ports: [String, 100]
+}
+```
+
+### Workload
+
+```rust
+struct Workload {
+    id: String,
+    name: String,
+    type: Type,
+    uri: String,
+    environment: [String, 100],
+    resources: Resources,
+    ports: [String, 100]
+}
+```
+
+### Type
+
+```rust
+enum Type {
+    CONTAINER
+}
+```
+
+### State
+
+```rust
+enum Status {
+    RUNNING,
+    STARTING,
+    STOPPED,
+    STOPPING,
+    DESTROYING,
+    TERMINATED,
+    CRASHED,
+    FAILED,
+    SCHEDULING,
+    SCHEDULED
+}
+```
+
+### Resources
+
+```rust
+struct Resource {
+    cpu: i32,
+    memory: i32,
+    disk: i32
+}
+```
+
+```rust
+struct ResourceClaim {
+    max: Resource,
+    usage: Resource
+}
+```
+
+# Internal API
+
+---
+
+## Internal Structures
+
+### Messages
+
+```protobuf
+// Represents an Instance status message
+message InstanceStatus {
+    string id = 1;
+    Status status = 2;
+    string description = 3;
+}
+
+// Represents a Node status message
+message NodeStatus {
+    string id = 1;
+    Status status = 2;
+    string description = 3;
+    Resource resource = 4;
+    [] Instance instances = 5;
+}
+
+//Represents an Instance running
+message Instance {
+    string id = 1;
+    string name = 2;
+    Type type = 3;
+    Status status = 4;
+    string uri = 5;
+    [] string environnement = 6;
+    Resource resource = 7;
+    [] string ports = 8;
+    string ip = 9;
+}
+
+//Represents a Resource entry
+message ResourceSummary {
+    int cpu = 1;
+    int memory = 2;
+    int disk = 3;
+}
+
+//Represents the resources used & threshold
+message Resource {
+    ResourceSummary max = 1;
+    ResourceSummary usage = 2;
+}
+```
+
+### Enums
+
+```protobuf
+//Represents the liveness status of
+enum Status {
+    RUNNING = 0;
+    STARTING = 1;
+    STOPPED = 2;
+    STOPPING = 3;
+    DESTROYING = 4;
+    TERMINATED = 5;
+    CRASHED = 6;
+    FAILED = 7;
+    SCHEDULING = 8;
+    SCHEDULED = 9;
+}
+
+//Represents the type of workload running
+enum Type {
+    CONTAINER = 0;
+}
+```
+
+## Functions
+
+### Controller → Scheduler (gRPC)
+
+```protobuf
+service SchedulerService {
+    rpc setNodeStatus(NodeStatus) returns (google.protobuf.Empty) {}
+    rpc setInstanceStatus(InstanceStatus) returns (google.protobuf.Empty) {}
+}
+
+```

--- a/docs/proposal/controller/external-api.yml
+++ b/docs/proposal/controller/external-api.yml
@@ -1,0 +1,643 @@
+openapi: 3.0.1
+info:
+  title: 🛠️ KUDO External API (WIP)
+  description: |
+    External API for the KUDO project. This API is divided into 2 parts : 
+       
+    `Workload` : Configuration of a desired instance state  
+      
+    `Instance` : Running VM/container/binary
+  license:
+    name: MIT
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+servers:
+  - url: https://localhost/kudo/api/v0
+tags:
+  - name: instance
+    description: Everything about instances
+  - name: workload
+    description: Description of different workloads
+paths:
+  /workload/:
+    get:
+      tags:
+        - workload
+      summary: Get a list of stored workloads
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: number
+        - name: offset
+          in: query
+          schema:
+            type: number
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum:
+              - CONTAINER
+      responses:
+        200:
+          description: List of workloads stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: object
+                    description: Total number of workload registered
+                  workloads:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Workload"
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    put:
+      tags:
+        - workload
+      summary: Create a workload
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Workload"
+      responses:
+        201:
+          description: Id of the created workload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the created workload
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+  /workload/{id}:
+    get:
+      tags:
+        - workload
+      summary: Get detailled information about a workload
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Information about the workload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Workload"
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Workload not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        412:
+          description: Resources doesn't meet conditions
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    patch:
+      tags:
+        - workload
+      summary: Update a workload
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Workload"
+      responses:
+        200:
+          description: Id of the updated workload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the updated workload
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Workload not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    delete:
+      tags:
+        - workload
+      summary: Delete a workload
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Id of the deleted workload
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the deleted workload
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Workload not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+  /instance/:
+    get:
+      tags:
+        - instance
+      summary: Get a list of registered instances inside the cluster
+      parameters:
+        - name: limit
+          in: query
+          schema:
+            type: number
+        - name: offset
+          in: query
+          schema:
+            type: number
+        - name: type
+          in: query
+          schema:
+            type: string
+            enum:
+              - CONTAINER
+        - name: status
+          in: query
+          schema:
+            type: string
+            enum:
+              - RUNNING
+              - STARTING
+              - STOPPED
+              - STOPPING
+              - DESTROYING
+              - TERMINATED
+              - CRASHED
+              - FAILED
+              - SCHEDULING
+              - SCHEDULED
+      responses:
+        200:
+          description: List of instances in the cluster
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  count:
+                    type: number
+                    description: Total number of instances registered
+                  instances:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/Instance"
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    put:
+      tags:
+        - instance
+      summary: Create an instance
+      parameters:
+        - name: workloadId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        201:
+          description: Id of the created instance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the created instance
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+  /instance/{id}:
+    get:
+      tags:
+        - instance
+      summary: Get detailled information about an instance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Information about the instance
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Instance"
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Instance not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    patch:
+      tags:
+        - instance
+      summary: Update an instance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: workloadId
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Id of the updated instance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the updated instance
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Instance not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+    delete:
+      tags:
+        - instance
+      summary: Delete an instance
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: Id of the deleted instance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
+                    description: Id of the deleted instance
+        400:
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        404:
+          description: Instance not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+        500:
+          description: Internal server error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  error:
+                    type: string
+                    description: Error message
+components:
+  schemas:
+    Workload:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Id of the workload
+        name:
+          type: string
+          description: Name of the workload
+        type:
+          type: string
+          description: Type of the workload
+          enum:
+            - CONTAINER
+        uri:
+          type: string
+          description: URI from where to fetch the resource
+        ports:
+          type: array
+          description: Ports to expose
+          items:
+            type: string
+        env:
+          type: array
+          description: Environment variables
+          items:
+            type: string
+        resources:
+          type: object
+          description: Resources to allocate
+          properties:
+            cpu:
+              type: string
+              description: Number of CPU
+            memory:
+              type: string
+              description: Memory in MB
+            storage:
+              type: string
+              description: Storage in GB
+    Instance:
+      type: object
+      properties:
+        id:
+          type: string
+          description: Id of the instance
+        name:
+          type: string
+          description: Name of the instance
+        type:
+          type: string
+          description: Type of the workload
+          enum:
+            - CONTAINER
+        uri:
+          type: string
+          description: URI from where to fetch the resource
+        ports:
+          type: array
+          items:
+            type: string
+          description: Ports to expose
+        env:
+          type: array
+          items:
+            type: string
+          description: Environment variables
+        resources:
+          type: object
+          description: Resources to allocate
+          properties:
+            cpu:
+              type: string
+              description: Number of CPU
+            memory:
+              type: string
+              description: Memory in MB
+            storage:
+              type: string
+              description: Storage in GB
+        status:
+          type: string
+          description: Status of the instance
+          enum:
+            - RUNNING
+            - STARTING
+            - STOPPED
+            - STOPPING
+            - DESTROYING
+            - TERMINATED
+            - CRASHED
+            - FAILED
+            - SCHEDULING
+            - SCHEDULED

--- a/docs/proposal/controller/internal-api.proto
+++ b/docs/proposal/controller/internal-api.proto
@@ -1,0 +1,64 @@
+syntax = "proto3";
+
+package kudo.controller;
+
+//Represents the liveness status of 
+enum Status {
+    RUNNING = 0;
+    STARTING = 1;
+    STOPPED = 2;
+    STOPPING = 3;
+    DESTROYING = 4;
+    TERMINATED = 5;
+    CRASHED = 6;
+    FAILED = 7;
+    SCHEDULING = 8;
+    SCHEDULED = 9;
+}
+
+//Represents the type of workload running
+enum Type {
+    CONTAINER = 0;
+}
+
+// Represents a Instance status message
+message InstanceStatus {
+	string id = 1;
+	Status status = 2;
+	string description = 3;
+}
+
+// Represents a Node status message
+message NodeStatus {
+	string id = 1;
+	Status status = 2;
+	string description = 3;
+	Resource resource = 4;
+	repeated Instance instances = 5;
+}
+
+//Represents an Instance running
+message Instance {
+    string id = 1;
+    string name = 2;
+    Type type = 3;
+    Status status = 4;
+    string uri = 5;
+    repeated string environnement = 6;
+    Resource resource = 7;
+    repeated string ports = 8;
+    string ip = 9;
+}
+
+//Prepresent a resource entry
+message ResourceSummary {
+    int32 cpu = 1;
+    int32 memory = 2;
+    int32 disk = 3;
+}
+
+//Represents the resources used & threshold
+message Resource {
+    ResourceSummary max = 1;
+    ResourceSummary usage = 2;
+}


### PR DESCRIPTION
Close #12 

## Overall explanation of your work :
We've added an open API 3.0 description of our external API and defined our `.proto` that will interface with the scheduler.

## Technical decisions you've made and why :
Open API 3.0, to describe the best way our API to the client.

## Tasks lists :

- [x] External API
  - [x] Workload routes
  - [x] Instance routes
  - [x] Workload structure
  - [x] Instance structure
- [x] Internal API
  - [x] Set Node state service
  - [x] Set Instance state service
  - [x] Node structure
  - [x] Instance structure
- [x] Documentation